### PR TITLE
Fix Meter __init__ border_color type hint

### DIFF
--- a/tkdial/meter.py
+++ b/tkdial/meter.py
@@ -17,7 +17,7 @@ class Meter(tk.Canvas):
                  text_color: str = "black",
                  text_font: str = None,
                  border_width: int = 1,
-                 border_color: int = "grey40",
+                 border_color: str = "grey40",
                  major_divisions: int = 10,
                  minor_divisions: int = 1,
                  start_angle: int = 240,


### PR DESCRIPTION
The type of border_color should be str instead of int. I checked its uses, and it is always used as a str.